### PR TITLE
Make puma config more flexible

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -6,12 +6,13 @@
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum, this matches the default thread size of Active Record.
 #
-threads_count = ENV.fetch("RAILS_MAX_THREADS", 5).to_i
-threads threads_count, threads_count
+max_threads = ENV.fetch("RAILS_MAX_THREADS", 5).to_i
+min_threads = ENV.fetch("RAILS_MIN_THREADS", 5).to_i
+threads max_threads, min_threads
 
 # Specifies the `port` that Puma will listen on to receive requests, default is 3000.
 #
-port ENV.fetch("PORT", 3000)
+port ENV.fetch("PUMA_PORT", 3000)
 
 # Specifies the `environment` that Puma will run in.
 #


### PR DESCRIPTION
- Added specific Env vars for min and max thread
- Use `PUMA_PORT` instead of `PORT`