### PR TITLE
Update term_customizer

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/mainio/decidim-module-term_customizer.git
-  revision: 9133eea57ebfc4164b640efd1ac6b9ca1628c793
+  revision: 32b47529c192071cfc4caca5fa203ee9e8fd2c6b
   branch: main
   specs:
     decidim-term_customizer (0.28.0)


### PR DESCRIPTION
The current version of the Terms Customizer was not loading the form for adding new restrictions correctly and was causing the buttons to malfunction.

When you try to add a new constraint the form is submitted:
<img width="2303" height="797" alt="Captura desde 2026-01-20 10-08-43" src="https://github.com/user-attachments/assets/d6dbb9f0-f236-4a40-9d7c-f3e43700ebfa" />

It has been updated to the latest commit to fix this problem:
<img width="2303" height="867" alt="Captura desde 2026-01-20 10-12-00" src="https://github.com/user-attachments/assets/09b237b3-4f7e-4ea1-a7d0-d9d5f86586a9" />
