### PR TITLE
Fix SMPT settings

### DIFF
--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -137,9 +137,10 @@ default: &default
   smtp_password: <%= ENV["SMTP_PASSWORD"] %>
   smtp_address: <%= ENV["SMTP_ADDRESS"] %>
   smtp_domain: <%= ENV["SMTP_DOMAIN"] %>
-  smtp_port: <%= ENV["SMTP_PORT"] || "587" %>
-  smtp_starttls_auto: true
+  smtp_port: <%= ENV["SMTP_PORT"] || "465" %>
+  smtp_starttls_auto: false
   smtp_authentication: "plain"
+  tls: true
 
 development:
   <<: *default


### PR DESCRIPTION
The service was failing to establish the expected connection due to incorrect settings.

This PR change corrects the configuration to restore normal operation.